### PR TITLE
Remove wrong use of `entry_points` on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,4 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ),
-
-    entry_points={
-        'console_scripts': [
-            'jikji = jikji.cli:main',
-        ],
-    },
 )


### PR DESCRIPTION
Remove below code on `setup.py`
```python
entry_points={
	'console_scripts': [
		'jikji = jikji.cli:main',
	],
},
```